### PR TITLE
Fix interpreter

### DIFF
--- a/g203-led.py
+++ b/g203-led.py
@@ -1,4 +1,4 @@
-#!env/bin/python
+#!/usr/bin/env python3
 
 # Logitech G203 Prodigy Mouse LED control
 # https://github.com/smasty/g203-led


### PR DESCRIPTION
> `env/bin/python: bad interpreter: No such file or directory`

The script seems perfectly compatible with python3 and works without needing a special setup, so why bother with a relative interpreter path that will not exist on anyone's system? I'd propose to just use the POSIX `/usr/bin/env python3` as interpreter.